### PR TITLE
Run asc creation through celery

### DIFF
--- a/backend/server/schemas/project.py
+++ b/backend/server/schemas/project.py
@@ -2,6 +2,7 @@ import graphene
 
 from graphene_django.types import DjangoObjectType
 from graphene import ObjectType
+from web3 import Web3
 
 from backend.server.models import Project
 import backend.server.utils.github as github
@@ -203,6 +204,9 @@ class CreateProject(graphene.Mutation):
         if mycro_project is None:
             raise ProjectException(
                 "Could not find mycro dao. Cannot create new project.")
+
+        if not Web3.isAddress(creator_address):
+            raise ProjectException('Supplied address is not valid')
 
 
         total_supply = 1000

--- a/backend/tests/contracts/test_base_dao.py
+++ b/backend/tests/contracts/test_base_dao.py
@@ -1,86 +1,92 @@
-from eth_tester.exceptions import TransactionFailed
 import unittest
-from backend.tests.testing_utilities.utils import *
+
+from eth_tester.exceptions import TransactionFailed
+
 import backend.tests.testing_utilities.constants as constants
+from backend.tests.testing_utilities.utils import *
 
 
 class TestBaseDao(unittest.TestCase):
 
     def setUp(self):
+        self.w3 = constants.create_w3()
         self.base_dao_interface = constants.COMPILER.get_contract_interface(
             "base_dao.sol", "BaseDao")
-        self.dao_contract, self.dao_address, self.dao_instance = deploy_base_dao()
+        self.dao_contract, self.dao_address, self.dao_instance = deploy_base_dao(
+            self.w3)
 
     def test_can_propose(self):
-        asc_address = constants.W3.eth.accounts[1]
+        asc_address = self.w3.eth.accounts[1]
         self.dao_instance.propose(asc_address, transact={
-            'from': constants.W3.eth.accounts[0]})
+            'from': self.w3.eth.accounts[0]})
         proposals = self.dao_instance.getProposals()
 
         self.assertEqual(1, len(proposals))
         self.assertEqual(str(asc_address), proposals[0])
 
     def test_vote_fails_for_unproposed_asc(self):
-        asc_address = constants.W3.eth.accounts[1]
+        asc_address = self.w3.eth.accounts[1]
 
         with self.assertRaises(TransactionFailed):
             self.dao_instance.vote(asc_address, transact={
-                'from': constants.W3.eth.accounts[0]})
+                'from': self.w3.eth.accounts[0]})
 
     def test_vote_fails_when_voting_second_time(self):
-        __, asc_address, __ = create_and_propose_merge_asc(self.dao_instance)
-
+        __, asc_address, __ = create_and_propose_merge_asc(self.w3,
+                                                           self.dao_instance)
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[0]})
+                               transact={'from': self.w3.eth.accounts[0]})
 
         with self.assertRaises(TransactionFailed):
             self.dao_instance.vote(asc_address, transact={
-                'from': constants.W3.eth.accounts[0]})
+                'from': self.w3.eth.accounts[0]})
 
     def test_propose_same_asc_twice_fails(self):
-        asc_address = constants.W3.eth.accounts[1]
+        asc_address = self.w3.eth.accounts[1]
 
         self.dao_instance.propose(asc_address, transact={
-            'from': constants.W3.eth.accounts[0]})
+            'from': self.w3.eth.accounts[0]})
 
         with self.assertRaises(TransactionFailed):
             self.dao_instance.propose(asc_address, transact={
-                'from': constants.W3.eth.accounts[0]})
+                'from': self.w3.eth.accounts[0]})
 
     def test_starting_balance(self):
-        balance = self.dao_instance.balanceOf(constants.W3.eth.accounts[7])
+        balance = self.dao_instance.balanceOf(self.w3.eth.accounts[7])
 
         self.assertEqual(33, balance)
 
     def test_register_module(self):
-        __, merge_address, __ = create_and_register_merge_module(self.dao_instance)
+        __, merge_address, __ = create_and_register_merge_module(self.w3,
+                                                                 self.dao_instance)
 
         dummy_module_interface = constants.COMPILER.get_contract_interface(
             "dummy_module.sol", "DummyModule")
-        _, dummy_module_address, _ = deploy_contract(constants.W3,
-                                                      dummy_module_interface)
+        _, dummy_module_address, _ = deploy_contract(self.w3,
+                                                     dummy_module_interface)
 
         self.assertTrue(self.dao_instance.isModuleRegistered(merge_address))
         self.assertFalse(
             self.dao_instance.isModuleRegistered(dummy_module_address))
 
     def test_vote_passes_threshold_executes_asc(self):
-        _, asc_address, asc_instance = create_and_propose_merge_asc(
-            self.dao_instance)
+        _, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                    self.dao_instance)
 
-        merge_contract, merge_address, merge_instance = create_and_register_merge_module(self.dao_instance)
+        merge_contract, merge_address, merge_instance = create_and_register_merge_module(
+            self.w3, self.dao_instance)
         event_filter = merge_contract.events.Merge.createFilter(
             argument_filters={'filter': {'event': 'Merge'}},
             fromBlock=0)
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[7]})
+                               transact={'from': self.w3.eth.accounts[7]})
 
         self.assertEqual(0, len(event_filter.get_new_entries()))
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[8]})
+                               transact={'from': self.w3.eth.accounts[8]})
 
         entries = event_filter.get_new_entries()
 
@@ -96,18 +102,19 @@ class TestBaseDao(unittest.TestCase):
                          merge_instance.pullRequestsToMerge())
 
     def test_vote_for_executed_asc_doesnt_do_raise_new_merge_event(self):
-        _, asc_address, asc_instance = create_and_propose_merge_asc(
-            self.dao_instance)
+        _, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                    self.dao_instance)
 
-        merge_contract, merge_address, __ = create_and_register_merge_module(self.dao_instance)
+        merge_contract, merge_address, __ = create_and_register_merge_module(
+            self.w3, self.dao_instance)
         event_filter = merge_contract.events.Merge.createFilter(
             argument_filters={'filter': {'event': 'Merge'}},
             fromBlock=0)
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[7]})
+                               transact={'from': self.w3.eth.accounts[7]})
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[8]})
+                               transact={'from': self.w3.eth.accounts[8]})
 
         entries = event_filter.get_new_entries()
 
@@ -116,7 +123,7 @@ class TestBaseDao(unittest.TestCase):
         self.assertEqual(constants.PR_ID, entries[0]["args"]["prId"])
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[9]})
+                               transact={'from': self.w3.eth.accounts[9]})
         entries = event_filter.get_new_entries()
 
         self.assertEqual(0, len(entries))
@@ -127,33 +134,35 @@ class TestBaseDao(unittest.TestCase):
     def test_vote_threshold_updates_after_asc_executes(self):
         reward = 50
 
-        create_and_register_merge_module(self.dao_instance)
+        create_and_register_merge_module(self.w3, self.dao_instance)
 
-        _, asc_address, asc_instance = create_and_propose_merge_asc(
-            self.dao_instance, reward=reward)
+        _, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                    self.dao_instance,
+                                                                    reward=reward)
 
         # vote so the ASC passes
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[7]})
+                               transact={'from': self.w3.eth.accounts[7]})
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[8]})
+                               transact={'from': self.w3.eth.accounts[8]})
 
         self.assertEqual(constants.TOTAL_SUPPLY + reward,
                          self.dao_instance.totalSupply())
 
         # deploy new ASC
-        _, asc_address, asc_instance = create_and_propose_merge_asc(
-            self.dao_instance, reward=reward)
+        _, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                    self.dao_instance,
+                                                                    reward=reward)
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[7]})
+                               transact={'from': self.w3.eth.accounts[7]})
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[8]})
+                               transact={'from': self.w3.eth.accounts[8]})
 
         self.assertFalse(asc_instance.hasExecuted())
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[9]})
+                               transact={'from': self.w3.eth.accounts[9]})
 
         self.assertTrue(asc_instance.hasExecuted())
 
@@ -179,16 +188,16 @@ class TestBaseDao(unittest.TestCase):
 
         # transfer 10 tokens to accounts[6] from accounts[7]
         with self.assertRaises(TransactionFailed):
-            self.dao_instance.transfer(constants.W3.eth.accounts[6], 10, transact={
-                'from': constants.W3.eth.accounts[7]})
+            self.dao_instance.transfer(self.w3.eth.accounts[6], 10, transact={
+                'from': self.w3.eth.accounts[7]})
 
         self.assertEqual(0, self.dao_instance.balanceOf(
-            constants.W3.eth.accounts[6]))
+            self.w3.eth.accounts[6]))
         self.assertEqual(
             constants.INITIAL_ADDRESSES,
             self.dao_instance.getTransactors())
         self.assertEqual(33, self.dao_instance.balanceOf(
-            constants.W3.eth.accounts[7]))
+            self.w3.eth.accounts[7]))
         self.assertEqual(0, len(event_filter.get_new_entries()))
 
     def test_transfer_from_fails(self):
@@ -200,61 +209,60 @@ class TestBaseDao(unittest.TestCase):
 
         # approve accounts[6]
         num_tokens = 10
-        self.dao_instance.approve(constants.W3.eth.accounts[6], num_tokens,
+        self.dao_instance.approve(self.w3.eth.accounts[6], num_tokens,
                                   transact={
-                                      'from': constants.W3.eth.accounts[7]})
+                                      'from': self.w3.eth.accounts[7]})
 
         with self.assertRaises(TransactionFailed):
-            self.dao_instance.transferFrom(constants.W3.eth.accounts[7],
-                                           constants.W3.eth.accounts[6], num_tokens,
+            self.dao_instance.transferFrom(self.w3.eth.accounts[7],
+                                           self.w3.eth.accounts[6], num_tokens,
                                            transact={
-                                               'from': constants.W3.eth.accounts[
+                                               'from': self.w3.eth.accounts[
                                                    6]})
 
         self.assertEqual(0, self.dao_instance.balanceOf(
-            constants.W3.eth.accounts[6]))
+            self.w3.eth.accounts[6]))
         self.assertEqual(
             constants.INITIAL_ADDRESSES,
             self.dao_instance.getTransactors())
         self.assertEqual(33, self.dao_instance.balanceOf(
-            constants.W3.eth.accounts[7]))
+            self.w3.eth.accounts[7]))
         self.assertEqual(0, len(event_filter.get_new_entries()))
 
-
     def test_upgrade_symbol_not_the_same(self):
-        __, __, new_dao_instance = deploy_base_dao(symbol='dif')
+        __, __, new_dao_instance = deploy_base_dao(self.w3, symbol='dif')
 
         # expected to not throw for now
         new_dao_instance.upgradeFrom(self.dao_address)
 
     def test_upgrade_name_not_the_same(self):
-        __, __, new_dao_instance = deploy_base_dao(name='dif')
+        __, __, new_dao_instance = deploy_base_dao(self.w3, name='dif')
 
         # expected to not throw for now
         new_dao_instance.upgradeFrom(self.dao_address)
 
     def test_upgrade_decimals_not_the_same(self):
-        __, __, new_dao_instance = deploy_base_dao(decimals=1)
+        __, __, new_dao_instance = deploy_base_dao(self.w3, decimals=1)
 
         with self.assertRaises(TransactionFailed):
             new_dao_instance.upgradeFrom(self.dao_address)
 
     def test_upgrade_works_as_expected(self):
         # create, propose and vote for an ASC
-        _, asc_address, _ = create_and_propose_merge_asc(self.dao_instance)
-
+        _, asc_address, _ = create_and_propose_merge_asc(self.w3,
+                                                         self.dao_instance)
 
         self.dao_instance.vote(asc_address,
-                               transact={'from': constants.W3.eth.accounts[0]})
+                               transact={'from': self.w3.eth.accounts[0]})
 
         # create and register a module
-        create_and_register_merge_module(self.dao_instance)
+        create_and_register_merge_module(self.w3, self.dao_instance)
 
-        __, __, new_dao_instance = deploy_base_dao(totalSupply=1,
+        __, __, new_dao_instance = deploy_base_dao(self.w3, totalSupply=1,
                                                    initalAddresses=[],
                                                    initialBalances=[])
         new_dao_instance.upgradeFrom(self.dao_address, transact={
-            'from': constants.W3.eth.accounts[0]})
+            'from': self.w3.eth.accounts[0]})
 
         self.assertEqual(new_dao_instance.name(), self.dao_instance.name())
         self.assertEqual(new_dao_instance.symbol(), self.dao_instance.symbol())

--- a/backend/tests/contracts/test_merge_asc.py
+++ b/backend/tests/contracts/test_merge_asc.py
@@ -1,23 +1,28 @@
 import unittest
+
 from eth_tester.exceptions import TransactionFailed
+
 from backend.tests.testing_utilities.utils import *
 
 
 class TestMergeAsc(unittest.TestCase):
 
+    def setUp(self):
+        self.w3 = constants.create_w3()
+
     def test_get_rewardee(self):
-        _, _, merge_asc_instance = create_merge_asc()
+        _, _, merge_asc_instance = create_merge_asc(self.w3)
         self.assertEqual(constants.REWARDEE, merge_asc_instance.rewardee())
 
     def test_get_reward(self):
-        _, _, merge_asc_instance = create_merge_asc()
+        _, _, merge_asc_instance = create_merge_asc(self.w3)
         self.assertEqual(constants.REWARD, merge_asc_instance.reward())
 
     def test_upgrade_from_executed_asc_fails(self):
-        __, __, dao_instance = deploy_base_dao()
-        create_and_register_merge_module(dao_instance)
-        __, asc_address, asc_instance = create_and_propose_merge_asc(
-            dao_instance)
+        __, __, dao_instance = deploy_base_dao(self.w3)
+        create_and_register_merge_module(self.w3, dao_instance)
+        __, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                     dao_instance)
 
         dao_instance.vote(asc_address,
                           transact={'from': constants.INITIAL_ADDRESSES[0]})
@@ -26,17 +31,17 @@ class TestMergeAsc(unittest.TestCase):
 
         self.assertTrue(asc_instance.hasExecuted())
 
-        __, __, new_asc_instance = create_merge_asc()
+        __, __, new_asc_instance = create_merge_asc(self.w3)
 
         with self.assertRaises(TransactionFailed):
             new_asc_instance.upgradeFrom(asc_address, transact={
-                'from': constants.W3.eth.accounts[0]})
+                'from': self.w3.eth.accounts[0]})
 
     def test_cannot_upgrade_already_executed_asc(self):
-        __, __, dao_instance = deploy_base_dao()
-        create_and_register_merge_module(dao_instance)
-        __, asc_address, asc_instance = create_and_propose_merge_asc(
-            dao_instance)
+        __, __, dao_instance = deploy_base_dao(self.w3)
+        create_and_register_merge_module(self.w3, dao_instance)
+        __, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                     dao_instance)
 
         dao_instance.vote(asc_address,
                           transact={'from': constants.INITIAL_ADDRESSES[0]})
@@ -45,23 +50,26 @@ class TestMergeAsc(unittest.TestCase):
 
         self.assertTrue(asc_instance.hasExecuted())
 
-        __, new_asc_address, __ = create_merge_asc()
+        __, new_asc_address, __ = create_merge_asc(self.w3)
 
         with self.assertRaises(TransactionFailed):
             asc_instance.upgradeFrom(new_asc_address, transact={
-                'from': constants.W3.eth.accounts[0]})
+                'from': self.w3.eth.accounts[0]})
 
     def test_upgrade_merge_asc_happy_case(self):
         rewardee = '0x1111111111111111111111111111111111111114'
         reward = 21
         pr_id = 13
 
-        __, __, dao_instance = deploy_base_dao()
-        create_and_register_merge_module(dao_instance)
-        __, asc_address, asc_instance = create_and_propose_merge_asc(
-            dao_instance, rewardee=rewardee, reward=reward, pr_id=pr_id)
+        __, __, dao_instance = deploy_base_dao(self.w3)
+        create_and_register_merge_module(self.w3, dao_instance)
+        __, asc_address, asc_instance = create_and_propose_merge_asc(self.w3,
+                                                                     dao_instance,
+                                                                     rewardee=rewardee,
+                                                                     reward=reward,
+                                                                     pr_id=pr_id)
 
-        __, __, new_asc_instance = create_merge_asc()
+        __, __, new_asc_instance = create_merge_asc(self.w3)
 
         self.assertNotEqual(new_asc_instance.rewardee(),
                             asc_instance.rewardee())
@@ -69,7 +77,7 @@ class TestMergeAsc(unittest.TestCase):
         self.assertNotEqual(new_asc_instance.prId(), asc_instance.prId())
 
         new_asc_instance.upgradeFrom(asc_address, transact={
-            'from': constants.W3.eth.accounts[0]})
+            'from': self.w3.eth.accounts[0]})
 
         self.assertEqual(rewardee, new_asc_instance.rewardee())
         self.assertEqual(reward, new_asc_instance.reward())

--- a/backend/tests/contracts/test_merge_module.py
+++ b/backend/tests/contracts/test_merge_module.py
@@ -1,26 +1,32 @@
 import unittest
-from backend.tests.testing_utilities.utils import deploy_contract
+
 import backend.tests.testing_utilities.constants as constants
+from backend.tests.testing_utilities.utils import deploy_contract
+
 
 class TestMergeModule(unittest.TestCase):
 
     def setUp(self):
-
-        self.merge_module_interface = constants.COMPILER.get_contract_interface("merge_module.sol", "MergeModule")
-        _, _, self.merge_module_instance = deploy_contract(constants.W3, self.merge_module_interface)
-
-
+        self.w3 = constants.create_w3()
+        self.merge_module_interface = constants.COMPILER.get_contract_interface(
+            "merge_module.sol", "MergeModule")
+        _, _, self.merge_module_instance = deploy_contract(self.w3,
+                                                           self.merge_module_interface)
 
     def test_get_name(self):
         self.assertEqual(1, self.merge_module_instance.getCode())
 
     def test_merge_adds_to_list(self):
-        self.merge_module_instance.merge(1, transact={'from': constants.W3.eth.accounts[0]})
+        self.merge_module_instance.merge(1, transact={
+            'from': self.w3.eth.accounts[0]})
 
         self.assertEqual([1], self.merge_module_instance.pullRequestsToMerge())
 
     def test_merge_adds_same_pr_twice_if_asked(self):
-        self.merge_module_instance.merge(1, transact={'from': constants.W3.eth.accounts[0]})
-        self.merge_module_instance.merge(1, transact={'from': constants.W3.eth.accounts[0]})
+        self.merge_module_instance.merge(1, transact={
+            'from': self.w3.eth.accounts[0]})
+        self.merge_module_instance.merge(1, transact={
+            'from': self.w3.eth.accounts[0]})
 
-        self.assertEqual([1, 1], self.merge_module_instance.pullRequestsToMerge())
+        self.assertEqual([1, 1],
+                         self.merge_module_instance.pullRequestsToMerge())

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,8 +1,12 @@
-from backend.tests.mycro_django_test import MycroDjangoTest
-from unittest.mock import patch, MagicMock, ANY
-from backend.server.models import Project, BlockchainState, ObjectDoesNotExist
-import backend.tests.testing_utilities.constants as constants
+from unittest.mock import ANY, MagicMock, patch
+
 import backend.server.tasks as tasks
+import backend.tests.testing_utilities.constants as constants
+import backend.tests.testing_utilities.utils as utils
+from backend.server.models import (
+    ASC, BlockchainState, ObjectDoesNotExist, Project, Transaction,
+)
+from backend.tests.mycro_django_test import MycroDjangoTest
 
 
 class TestTasks(MycroDjangoTest):
@@ -26,37 +30,38 @@ class TestTasks(MycroDjangoTest):
                                  constants.MYCRO_PROJECT_SYMBOL,
                                  constants.DECIMALS)
         project = Project.objects.create(symbol=constants.PROJECT_SYMBOL,
-                               repo_name=constants.PROJECT_NAME,
-                               decimals=constants.DECIMALS,
-                               initial_balances=constants.CREATORS_BALANCES)
+                                         repo_name=constants.PROJECT_NAME,
+                                         decimals=constants.DECIMALS,
+                                         initial_balances=constants.CREATORS_BALANCES)
 
+        # TODO make this more of an integration test by using constants.W3 like the create_asc tests
         w3 = get_w3_mock.return_value
         w3.eth.waitForTransactionReceipt.return_value = {
-            'contractAddress': constants.PROJECT_ADDRESS,
+            'contractAddress'  : constants.PROJECT_ADDRESS,
             'cumulativeGasUsed': 2,
-            'gasUsed': 1,
-            'blockNumber': 3,
-            'status': 4}
+            'gasUsed'          : 1,
+            'blockNumber'      : 3,
+            'status'           : 4}
         w3.eth.getBalance.return_value = int(10e18)
 
         tasks.create_project(project.pk)
 
         # two transactions, one for deploying and once for registering
         transaction_mock.objects.create.assert_any_call(
-                wallet=self.wallet,
-                hash=get_w3_mock.return_value.eth.sendRawTransaction.return_value.hex.return_value,
-                value=ANY,
-                chain_id=ANY,
-                nonce=ANY,
-                gas_limit=ANY,
-                gas_price=ANY,
-                data=ANY,
-                to=ANY,
-                contract_address=constants.PROJECT_ADDRESS,
-                cumulative_gas_used=2,
-                gas_used=1,
-                block_number=3,
-                status=4
+            wallet=self.wallet,
+            hash=get_w3_mock.return_value.eth.sendRawTransaction.return_value.hex.return_value,
+            value=ANY,
+            chain_id=ANY,
+            nonce=ANY,
+            gas_limit=ANY,
+            gas_price=ANY,
+            data=ANY,
+            to=ANY,
+            contract_address=constants.PROJECT_ADDRESS,
+            cumulative_gas_used=2,
+            gas_used=1,
+            block_number=3,
+            status=4
         )
 
         # called twice for deployment and twice for registrations
@@ -64,14 +69,16 @@ class TestTasks(MycroDjangoTest):
                          get_w3_mock.return_value.eth.waitForTransactionReceipt.call_count)
         self.assertEqual(4, w3.eth.sendRawTransaction.call_count)
 
-        create_repo_mock.assert_called_once_with(repo_name=constants.PROJECT_NAME, organization=github_organization_mock.return_value)
+        create_repo_mock.assert_called_once_with(
+            repo_name=constants.PROJECT_NAME,
+            organization=github_organization_mock.return_value)
 
         project.refresh_from_db()
         self.assertEqual(constants.PROJECT_ADDRESS, project.dao_address)
         self.assertEqual(BlockchainState.COMPLETED, project.blockchain_state)
         self.assertNotEqual('', project.merge_module_address)
 
-        redis_lock_mock.assert_called_once_with('create-project')
+        redis_lock_mock.assert_called_once_with(tasks.REDIS_CREATE_CONTRACT_LOCK)
 
     @patch('backend.server.tasks.StrictRedis.lock')
     @patch('backend.server.utils.deploy.Transaction')
@@ -79,12 +86,12 @@ class TestTasks(MycroDjangoTest):
     @patch('backend.server.utils.github.create_repo')
     @patch('backend.settings.github_organization')
     def test_create_project_project_does_not_exist(self,
-                                       github_organization_mock: MagicMock,
-                                       create_repo_mock: MagicMock,
-                                       get_w3_mock: MagicMock,
-                                       transaction_mock: MagicMock,
-                                       redis_lock_mock: MagicMock):
-
+                                                   github_organization_mock: MagicMock,
+                                                   create_repo_mock: MagicMock,
+                                                   get_w3_mock: MagicMock,
+                                                   transaction_mock: MagicMock,
+                                                   redis_lock_mock: MagicMock):
+        # TODO make this more of an integration test by using constants.W3 like the create_asc tests
         with self.assertRaisesRegex(ObjectDoesNotExist, 'Project matching'):
             tasks.create_project(Project.objects.count() + 1)
 
@@ -92,8 +99,102 @@ class TestTasks(MycroDjangoTest):
         create_repo_mock.assert_not_called()
         get_w3_mock.assert_not_called()
         transaction_mock.assert_not_called()
-        redis_lock_mock.assert_called_once_with('create-project')
+        redis_lock_mock.assert_called_once_with(tasks.REDIS_CREATE_CONTRACT_LOCK)
 
+    @patch('backend.server.tasks.StrictRedis.lock')
+    @patch('backend.server.utils.deploy.get_w3')
+    def test_create_asc_happy_case(self,
+                                   get_w3_mock: MagicMock,
+                                   redis_lock_mock: MagicMock):
+        get_w3_mock.return_value = constants.create_w3()
+        _, project_address, _ = utils.deploy_base_dao(constants.create_w3())
+        project = Project.objects.create(symbol=constants.PROJECT_SYMBOL,
+                                         repo_name=constants.PROJECT_NAME,
+                                         decimals=constants.DECIMALS,
+                                         initial_balances=constants.CREATORS_BALANCES,
+                                         dao_address=project_address)
+        asc = ASC.objects.create(rewardee=constants.REWARDEE,
+                                 reward=constants.REWARD,
+                                 pr_id=constants.PR_ID,
+                                 project=project,
+                                 blockchain_state=BlockchainState.PENDING)
 
+        tasks.create_asc(asc.id)
 
+        asc.refresh_from_db()
 
+        self.assertEqual(BlockchainState.COMPLETED, asc.blockchain_state)
+        self.assertNotEqual('', asc.address)
+
+        redis_lock_mock.assert_called_once_with(tasks.REDIS_CREATE_CONTRACT_LOCK)
+
+        transactions = Transaction.objects.all()
+
+        self.assertEqual(2, len(transactions))
+
+    @patch('backend.server.tasks.StrictRedis.lock')
+    @patch('backend.server.utils.deploy.get_w3')
+    def test_create_asc_when_not_pending(self,
+                                         get_w3_mock: MagicMock,
+                                         redis_lock_mock: MagicMock):
+        get_w3_mock.return_value = constants.create_w3()
+        _, project_address, _ = utils.deploy_base_dao(constants.create_w3())
+        project = Project.objects.create(symbol=constants.PROJECT_SYMBOL,
+                                         repo_name=constants.PROJECT_NAME,
+                                         decimals=constants.DECIMALS,
+                                         initial_balances=constants.CREATORS_BALANCES,
+                                         dao_address=project_address)
+        asc = ASC.objects.create(rewardee=constants.REWARDEE,
+                                 reward=constants.REWARD,
+                                 pr_id=constants.PR_ID,
+                                 project=project,
+                                 blockchain_state=BlockchainState.STARTED)
+
+        with self.assertRaisesRegex(AssertionError, 'pending'):
+            tasks.create_asc(asc.id)
+
+        asc.refresh_from_db()
+
+        # state must not be modified
+        self.assertEqual(BlockchainState.STARTED, asc.blockchain_state)
+        self.assertEqual('', asc.address)
+
+        redis_lock_mock.assert_called_once_with(tasks.REDIS_CREATE_CONTRACT_LOCK)
+
+        transactions = Transaction.objects.all()
+
+        self.assertEqual(0, len(transactions))
+
+    @patch('backend.server.tasks.StrictRedis.lock')
+    @patch('backend.server.utils.deploy.get_w3')
+    def test_create_asc_that_has_address(self,
+                                         get_w3_mock: MagicMock,
+                                         redis_lock_mock: MagicMock):
+        get_w3_mock.return_value = constants.create_w3()
+        _, project_address, _ = utils.deploy_base_dao(constants.create_w3())
+        project = Project.objects.create(symbol=constants.PROJECT_SYMBOL,
+                                         repo_name=constants.PROJECT_NAME,
+                                         decimals=constants.DECIMALS,
+                                         initial_balances=constants.CREATORS_BALANCES,
+                                         dao_address=project_address)
+        asc = ASC.objects.create(rewardee=constants.REWARDEE,
+                                 reward=constants.REWARD,
+                                 pr_id=constants.PR_ID,
+                                 project=project,
+                                 blockchain_state=BlockchainState.PENDING,
+                                 address=constants.ASC_ADDRESS)
+
+        with self.assertRaisesRegex(AssertionError, 'address'):
+            tasks.create_asc(asc.id)
+
+        asc.refresh_from_db()
+
+        # state must not be modified
+        self.assertEqual(BlockchainState.PENDING, asc.blockchain_state)
+        self.assertEqual(constants.ASC_ADDRESS, asc.address)
+
+        redis_lock_mock.assert_called_once_with(tasks.REDIS_CREATE_CONTRACT_LOCK)
+
+        transactions = Transaction.objects.all()
+
+        self.assertEqual(0, len(transactions))

--- a/backend/tests/testing_utilities/constants.py
+++ b/backend/tests/testing_utilities/constants.py
@@ -1,16 +1,26 @@
-from backend.server.utils.contract_compiler import ContractCompiler
-from web3 import Web3, Account
-from web3.providers.eth_tester import EthereumTesterProvider
 from eth_tester import EthereumTester
+from web3 import Account, Web3
+from web3.providers.eth_tester import EthereumTesterProvider
+
 import backend.constants as app_constants
+from backend.server.utils.contract_compiler import ContractCompiler
 
 COMPILER = ContractCompiler()
-TESTER = EthereumTester()
-TESTER.add_account(app_constants.DEFAULT_ETHEREUM_PRIVATE_KEY)
-W3 = Web3(EthereumTesterProvider(ethereum_tester=TESTER))
 
-TESTER.send_transaction({'from': W3.eth.accounts[0], 'to': app_constants.DEFAULT_ETHEREUM_ADDRESS, 'gas': 21000, 'value': int(10e18)})
 
+def create_w3():
+    tester = EthereumTester()
+    tester.add_account(app_constants.DEFAULT_ETHEREUM_PRIVATE_KEY)
+    w3 = Web3(EthereumTesterProvider(ethereum_tester=tester))
+
+    tester.send_transaction({'from': w3.eth.accounts[0],
+                             'to'  : app_constants.DEFAULT_ETHEREUM_ADDRESS,
+                             'gas' : 21000, 'value': int(10e18)})
+
+    return w3
+
+
+W3_ACCOUNTS = create_w3().eth.accounts
 
 # hardcoded Ethereum addresses
 PROJECT_ADDRESS = '0x1111111111111111111111111111111111111111'
@@ -30,9 +40,10 @@ PR_ID = 11
 SYMBOL = 'lol'
 NAME = 'lolcoin'
 DECIMALS = 18
-CREATORS_BALANCES = {W3.eth.accounts[7]: 33, W3.eth.accounts[8]: 33, W3.eth.accounts[9]: 34}
+CREATORS_BALANCES = {W3_ACCOUNTS[7]: 33, W3_ACCOUNTS[8]: 33, W3_ACCOUNTS[9]: 34}
 INITIAL_BALANCES = list(CREATORS_BALANCES.values())
 INITIAL_ADDRESSES = list(CREATORS_BALANCES.keys())
 TOTAL_SUPPLY = sum(INITIAL_BALANCES)
-WALLET = Account.privateKeyToAccount('f49e1216edac9a5b0fab36f28037bfe8d5eb104b13f049b59decfac446e56ab4') # default private key with a different final character (4 instead of 3)
+WALLET = Account.privateKeyToAccount(
+    'f49e1216edac9a5b0fab36f28037bfe8d5eb104b13f049b59decfac446e56ab4')  # default private key with a different final character (4 instead of 3)
 TRANSACTION = {'gas': 10, 'nonce': 1, 'gasLimit': 10, 'data': '0x123abc'}

--- a/backend/tests/testing_utilities/utils.py
+++ b/backend/tests/testing_utilities/utils.py
@@ -1,14 +1,14 @@
-import backend.tests.testing_utilities.constants as constants
 from web3.contract import ConciseContract
 
+import backend.tests.testing_utilities.constants as constants
+
+
 def deploy_contract(w3, contract_interface, *args):
-
-
     # Instantiate contract
     contract = w3.eth.contract(abi=contract_interface['abi'],
                                bytecode=contract_interface['bin'])
-    tx_hash = contract.constructor(*args).transact(transaction={'from': w3.eth.accounts[0]})
-
+    tx_hash = contract.constructor(*args).transact(
+        transaction={'from': w3.eth.accounts[0]})
 
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     contract_address = tx_receipt['contractAddress']
@@ -25,7 +25,7 @@ def deploy_contract(w3, contract_interface, *args):
     return contract, contract_address, contract_instance
 
 
-def deploy_base_dao(w3=constants.W3,
+def deploy_base_dao(w3,
                     symbol=constants.SYMBOL,
                     name=constants.NAME,
                     decimals=constants.DECIMALS,
@@ -35,26 +35,26 @@ def deploy_base_dao(w3=constants.W3,
     base_dao_interface = constants.COMPILER.get_contract_interface(
         "base_dao.sol", "BaseDao")
     return deploy_contract(w3, base_dao_interface,
-                            symbol,
-                            name,
-                            decimals,
-                            totalSupply,
-                            initalAddresses,
-                            initialBalances)
+                           symbol,
+                           name,
+                           decimals,
+                           totalSupply,
+                           initalAddresses,
+                           initialBalances)
 
 
-def create_and_register_merge_module(base_dao_instance, w3=constants.W3):
+def create_and_register_merge_module(w3, base_dao_instance):
     merge_module_interface = constants.COMPILER.get_contract_interface(
         "merge_module.sol", "MergeModule")
     merge_contract, merge_address, merge_instance = deploy_contract(w3,
-                                                                     merge_module_interface)
+                                                                    merge_module_interface)
     base_dao_instance.registerModule(merge_address,
                                      transact={'from': w3.eth.accounts[0]})
 
     return merge_contract, merge_address, merge_instance
 
 
-def create_and_propose_merge_asc(base_dao_instance, w3=constants.W3,
+def create_and_propose_merge_asc(w3, base_dao_instance,
                                  rewardee=constants.REWARDEE,
                                  reward=constants.REWARD,
                                  pr_id=constants.PR_ID):
@@ -67,7 +67,7 @@ def create_and_propose_merge_asc(base_dao_instance, w3=constants.W3,
     return asc_contract, asc_address, asc_instance
 
 
-def create_merge_asc(w3=constants.W3,
+def create_merge_asc(w3,
                      rewardee=constants.REWARDEE,
                      reward=constants.REWARD,
                      pr_id=constants.PR_ID):
@@ -75,4 +75,4 @@ def create_merge_asc(w3=constants.W3,
         "merge_asc.sol", "MergeASC")
 
     return deploy_contract(w3, merge_asc_interface,
-                            rewardee, reward, pr_id)
+                           rewardee, reward, pr_id)

--- a/backend/tests/utils/test_deploy.py
+++ b/backend/tests/utils/test_deploy.py
@@ -1,14 +1,14 @@
-import unittest
-from unittest.mock import patch, MagicMock, call, ANY
-import backend.server.utils.deploy as deploy
-from web3.middleware import geth_poa_middleware
-from web3.providers import HTTPProvider
+import asyncio
+from unittest.mock import ANY, MagicMock, patch
+
 from web3 import Account
+from web3.providers import HTTPProvider
+
+import backend.server.utils.deploy as deploy
 import backend.settings as settings
 import backend.tests.testing_utilities.constants as constants
-import asyncio
-from backend.tests.mycro_django_test import MycroDjangoTest
 from backend.server.models import Transaction, Wallet
+from backend.tests.mycro_django_test import MycroDjangoTest
 
 PARITY_ENDPOINT = 'a.b.c'
 INFURA_KEY = 'lol'
@@ -61,7 +61,7 @@ class TestDeploy(MycroDjangoTest):
                                     timeout=10)
 
     def test_deploy_contract_with_private_key(self):
-        w3 = constants.W3
+        w3 = constants.create_w3()
 
         contract_interface = constants.COMPILER.get_mycro_contract()
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1681,6 +1681,10 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
+    "bignumber.js": {
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -13289,16 +13293,13 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
         "xmlhttprequest": "*"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-        },
         "crypto-js": {
           "version": "3.1.8",
           "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",

--- a/frontend/src/components/ProjectPage/AscListItem.js
+++ b/frontend/src/components/ProjectPage/AscListItem.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Spinner from '../shared/Spinner.js';
 import AddressShortener from '../shared/AddressShortener.js';
 import { Contracts } from '../../services/Contracts.js';
 import './AscList.css';
@@ -166,9 +167,13 @@ class AscListItem extends Component {
               : this.renderFutureAwardMessage()}
           </div>
           <div>{asc.hasExecuted ? null : this.renderButton()}</div>
+          {asc.hasExecuted ? null : this.renderProgressBar()}
+          {/* TODO We need to coerce blockchain state from A_x to it's human for*/}
+          {/* A_2 is `COMPLETED`*/}
+          {/* TODO make this look not so shitty */}
+          {/* TODO holy shit this css/layout needs work*/}
+          {asc.blockchainState !== 'A_2' && <Spinner />}
         </div>
-
-        {asc.hasExecuted ? null : this.renderProgressBar()}
       </li>
     );
   }

--- a/frontend/src/services/Api.js
+++ b/frontend/src/services/Api.js
@@ -87,6 +87,7 @@ const getProjectQuery = address => {
         voters,
         hasExecuted,
         voteAmount,
+        blockchainState,
       },
       balances {
         address,


### PR DESCRIPTION
ASC creation is now done through celery and shares a lock with project
creation. This means the backend will only ever create a single
project/asc at a time. There are still reliability problems if one of
these tasks fails part way through. The CSS for the spinner while the
ASC is being created needs a LOT of work.

I also had to modify our tests to create a new W3 object for each test
because we were having trouble with the W3 object being mutated between
tests.

I think this is worth 1k coins.